### PR TITLE
Cache beartype wrappers across parametrized test items

### DIFF
--- a/src/pytest_beartype_tests/plugin.py
+++ b/src/pytest_beartype_tests/plugin.py
@@ -1,10 +1,21 @@
 """Pytest hook implementation."""
 
+from collections.abc import Callable
+from types import ModuleType
+
 import pytest
 from beartype import beartype
 
 
 def pytest_collection_modifyitems(items: list[pytest.Function]) -> None:
     """Apply the beartype decorator to all collected test functions."""
+    # Parametrized tests share one underlying function across many items;
+    # cache the wrapper so beartype only compiles it once per function.
+    cache: dict[
+        tuple[ModuleType | None, type | None, str], Callable[..., object]
+    ] = {}
     for item in items:
-        item.obj = beartype(obj=item.obj)
+        key = (item.module, item.cls, item.originalname)
+        if key not in cache:
+            cache[key] = beartype(obj=item.obj)
+        item.obj = cache[key]


### PR DESCRIPTION
## Summary
- Parametrized tests share one underlying function across many collected `pytest.Function` items; without caching, `beartype` recompiles a wrapper for each parametrization
- Cache the wrapper keyed on `(module, cls, originalname)` so each unique test function compiles exactly once
- Including `item.cls` in the key avoids a latent collision where two methods with the same `originalname` in different classes within one module would share a single wrapper

## Test plan
- [ ] `pytest` collection still succeeds on a consumer repo
- [ ] No regression in which tests get `@beartype` applied

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance change confined to the pytest collection hook; main risk is incorrect cache keying causing the wrong wrapper to be reused for a test function.
> 
> **Overview**
> **Improves pytest collection performance** by caching the `beartype`-decorated wrapper per underlying test function, instead of re-wrapping on every collected item (notably parametrizations).
> 
> The cache is keyed on `(item.module, item.cls, item.originalname)` to avoid collisions between same-named methods in different classes while ensuring each unique test function is wrapped once and then reused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d20999f80b8413e2270dc0b1ec4188d79394a81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->