### PR TITLE
Document plugin as workaround for pytest-beartype 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A tiny pytest plugin that applies [`beartype`](https://github.com/beartype/beart
 
 This is distinct from [`pytest-beartype`](https://pypi.org/project/pytest-beartype/), which beartypes your *source* packages. This plugin beartypes the *tests themselves*.
 
+> **Note:** This plugin is a temporary workaround until [`pytest-beartype`](https://pypi.org/project/pytest-beartype/) 0.3.0 is released, which is expected to provide this functionality natively (see https://github.com/beartype/pytest-beartype/issues/22). Once that release is available, you can migrate off this plugin.
+
 ## Install
 
 ```sh


### PR DESCRIPTION
## Summary
- Adds a note to the README explaining this plugin is a temporary workaround until `pytest-beartype` 0.3.0 ships native support for type-checking tests, with a link to the upstream tracking issue (beartype/pytest-beartype#22).

## Test plan
- [ ] Verify the README renders correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change with no code or behavior modifications.
> 
> **Overview**
> Adds a **README note** clarifying that `pytest-beartype-tests` is a temporary workaround until `pytest-beartype` `0.3.0` ships equivalent test type-checking support, with a link to the upstream tracking issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 547ce2abbcab33b21634c395b119788e87073dd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->