### PR TITLE
chore: use deptry optional_dependencies_dev_groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ ignore = [
 ]
 
 [tool.deptry]
-pep621_dev_dependency_groups = [
+optional_dependencies_dev_groups = [
     "dev",
 ]
 # pytest is required at runtime: it loads our plugin via the ``pytest11``


### PR DESCRIPTION
Renames `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups` for deptry 0.25+.

This removes deprecation warnings; the old key may be removed in a future deptry release.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a config-key rename in `pyproject.toml` that only affects dependency-lint tooling behavior and should not impact runtime code.
> 
> **Overview**
> Updates `pyproject.toml` to rename Deptry’s dev-dependency group configuration from the deprecated `pep621_dev_dependency_groups` to `optional_dependencies_dev_groups`, avoiding warnings on Deptry 0.25+.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 918cc1b89fff797c3c31bf6721c2034401b8cf8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->