### PR TITLE
Test that non-Function items are skipped

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -147,3 +147,20 @@ def test_return_annotation_is_enforced(pytester: pytest.Pytester) -> None:
     )
     result = pytester.runpytest()
     result.assert_outcomes(failed=1)
+
+
+def test_non_function_items_are_skipped(pytester: pytest.Pytester) -> None:
+    """Collected items that are not ``pytest.Function`` are left alone."""
+    _ = pytester.makepyfile(  # pyright: ignore[reportUnknownMemberType]
+        '''
+        def add(a: int, b: int) -> int:
+            """Add two numbers.
+
+            >>> add(1, 2)
+            3
+            """
+            return a + b
+        ''',
+    )
+    result = pytester.runpytest("--doctest-modules")
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
## Summary
- Adds a test that runs a doctest-collected item (a ``pytest.Item`` that is not a ``pytest.Function``) to cover the ``continue`` branch in ``pytest_collection_modifyitems``, restoring 100% coverage and unblocking CI.

## Test plan
- [x] ``uv run --extra=dev --python=3.12 coverage run -m pytest -s -vvv tests/``
- [x] ``uv run --extra=dev --python=3.12 coverage report`` (100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single behavioural test and does not change runtime plugin logic. Only affects test coverage around doctest/non-`pytest.Function` collection paths.
> 
> **Overview**
> Adds a new behavioural test ensuring `pytest_collection_modifyitems` leaves non-`pytest.Function` collected items (e.g., doctest module items) untouched by the beartype-wrapping logic.
> 
> The test runs `pytest` with `--doctest-modules` against a module containing a doctest and asserts the doctest item still passes, exercising the plugin’s early-`continue` branch for non-function items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e85622051b0a3307f423dd750024be6fb5135bd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->