### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,7 +86,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy --num-workers=4
+        entry: uv run --extra=dev -m mypy --num-workers=0
         language: python
         types_or: [python, toml]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,7 @@ repos:
         name: mypy
         stages: [pre-push]
         entry: uv run --extra=dev -m mypy
+        args: [--num-workers=4]
         language: python
         types_or: [python, toml]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,8 +86,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
-        args: [--num-workers=4]
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false


### PR DESCRIPTION
## Summary
- Add `--num-workers=4` to the pre-commit `mypy` hook args to enable parallel worker execution.

## Test plan
- [x] Let pre-commit run during commit
- [x] Verify `.pre-commit-config.yaml` contains the new mypy arg

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects developer pre-push checks; main risk is unexpected mypy performance/behavior differences on some machines due to worker parallelism.
> 
> **Overview**
> Updates the local pre-push `mypy` pre-commit hook to pass `--num-workers=0`, enabling mypy's parallel worker mode (auto-sized) when running via `uv run`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7927cf38bfa686098d5dc5e12a806382435657ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->