### PR TITLE
Add strict-kwargs via uv in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,6 @@ repos:
     hooks:
       - id: text-unicode-replacement-char
 
-
   - repo: local
     hooks:
       - id: actionlint
@@ -196,7 +195,6 @@ repos:
         types_or: [python]
         additional_dependencies:
           - *uv_version
-
 
       - id: strict-kwargs-fix
         name: strict-kwargs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ ci:
     - ruff-format-fix
     - shellcheck
     - shfmt
+    - strict-kwargs-fix
     - ty
     - pyrefly
     - vulture
@@ -57,11 +58,6 @@ repos:
     hooks:
       - id: text-unicode-replacement-char
 
-  - repo: https://github.com/adamtheturtle/strict-kwargs
-    rev: 2026.5.18
-    hooks:
-      - id: strict-kwargs
-        args: [fix]
 
   - repo: local
     hooks:
@@ -200,6 +196,16 @@ repos:
         types_or: [python]
         additional_dependencies:
           - *uv_version
+
+
+      - id: strict-kwargs-fix
+        name: strict-kwargs
+        entry: uv run --extra=dev strict-kwargs fix
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        require_serial: true
 
       - id: interrogate
         name: interrogate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,7 @@ dependencies = [
     "beartype>=0.18",
     "pytest>=8",
 ]
-optional-dependencies.dev = [
-    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "interrogate==1.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
     "beartype>=0.18",
     "pytest>=8",
 ]
-optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [
+    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "interrogate==1.7.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.25.0",
-
 ]
 optional-dependencies.release = [
     "check-wheel-contents==0.6.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ optional-dependencies.dev = [
     # use it to lint shell commands in GitHub workflow files.
     "shellcheck-py==0.11.0.1",
     "shfmt-py==4.0.0",
-    "strict-kwargs==2026.5.18",
+    "strict-kwargs==2026.5.18.post1",
     "ty==0.0.36",
     "vulture==2.16",
     "yamlfix==1.19.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.25.0",
+
 ]
 optional-dependencies.release = [
     "check-wheel-contents==0.6.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ optional-dependencies.dev = [
     # use it to lint shell commands in GitHub workflow files.
     "shellcheck-py==0.11.0.1",
     "shfmt-py==4.0.0",
+    "strict-kwargs==2026.5.18",
     "ty==0.0.36",
     "vulture==2.16",
     "yamlfix==1.19.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1111,6 +1111,7 @@ dev = [
     { name = "ruff" },
     { name = "shellcheck-py" },
     { name = "shfmt-py" },
+    { name = "strict-kwargs" },
     { name = "ty" },
     { name = "vulture" },
     { name = "yamlfix" },
@@ -1142,6 +1143,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.13" },
     { name = "shellcheck-py", marker = "extra == 'dev'", specifier = "==0.11.0.1" },
     { name = "shfmt-py", marker = "extra == 'dev'", specifier = "==4.0.0" },
+    { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.18" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.36" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
     { name = "yamlfix", marker = "extra == 'dev'", specifier = "==1.19.1" },
@@ -1282,6 +1284,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/a9/6fce944efa530db941edd11388d70dc7384aaf12169a3b0847b6a6c987b0/shfmt_py-4.0.0-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:4701336c3cb5f3959a5e85481b14f02054ea094b3c666f3d04649bbe10de3c25", size = 1218771, upload-time = "2026-05-13T09:25:46.225Z" },
     { url = "https://files.pythonhosted.org/packages/64/43/e3965a25bb39555f2791c6860214f62b6f976f9ac7e9786073364bcdd9a6/shfmt_py-4.0.0-py2.py3-none-manylinux2014_x86_64.whl", hash = "sha256:e57877abe0177a9da7bbb5390fe7e96aa19b00958189a025634039aef8834d44", size = 1350939, upload-time = "2026-05-13T09:25:47.584Z" },
     { url = "https://files.pythonhosted.org/packages/95/20/db2430d9262d2cffadcad2b330441e13031f1ab849ec069659edb7f23257/shfmt_py-4.0.0-py2.py3-none-win_amd64.whl", hash = "sha256:bd4f3d36264d4ba8b014ff73e5e702aaa2345845c021f563480128de3705135b", size = 1427721, upload-time = "2026-05-13T09:25:48.865Z" },
+]
+
+[[package]]
+name = "strict-kwargs"
+version = "2026.5.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ty" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/5f/214c7046d4fdb7562db842baeeb8b3dda4521c2736f4ac5fb10ab3397f0c/strict_kwargs-2026.5.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e60f890d25dde613b337eef035b96ed820acafdca46ec3349b35f4d5af55c5ac", size = 2088143, upload-time = "2026-05-18T10:43:13.197Z" },
+    { url = "https://files.pythonhosted.org/packages/79/0d/989af3f5eda8cd14bd80488e449f8f40d81709de44dd376f309df83bb726/strict_kwargs-2026.5.18-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:2ce07d85420eed40e51b0a61681db39fd56ed2be97f73780ef2be97ef9373c1b", size = 2187277, upload-time = "2026-05-18T10:43:14.783Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/ea/8c711d39423fa503f94a4afd5913e3d5ae2f87d1e9009d2219e47c78c473/strict_kwargs-2026.5.18-py3-none-win_amd64.whl", hash = "sha256:c90ae750b5754176e943bebaee42d34e51433ead05da60908159b42059ccea75", size = 1983606, upload-time = "2026-05-18T10:43:16.493Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1143,7 +1143,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.13" },
     { name = "shellcheck-py", marker = "extra == 'dev'", specifier = "==0.11.0.1" },
     { name = "shfmt-py", marker = "extra == 'dev'", specifier = "==4.0.0" },
-    { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.18" },
+    { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.18.post1" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.36" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
     { name = "yamlfix", marker = "extra == 'dev'", specifier = "==1.19.1" },
@@ -1288,15 +1288,15 @@ wheels = [
 
 [[package]]
 name = "strict-kwargs"
-version = "2026.5.18"
+version = "2026.5.18.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ty" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/5f/214c7046d4fdb7562db842baeeb8b3dda4521c2736f4ac5fb10ab3397f0c/strict_kwargs-2026.5.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e60f890d25dde613b337eef035b96ed820acafdca46ec3349b35f4d5af55c5ac", size = 2088143, upload-time = "2026-05-18T10:43:13.197Z" },
-    { url = "https://files.pythonhosted.org/packages/79/0d/989af3f5eda8cd14bd80488e449f8f40d81709de44dd376f309df83bb726/strict_kwargs-2026.5.18-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:2ce07d85420eed40e51b0a61681db39fd56ed2be97f73780ef2be97ef9373c1b", size = 2187277, upload-time = "2026-05-18T10:43:14.783Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/ea/8c711d39423fa503f94a4afd5913e3d5ae2f87d1e9009d2219e47c78c473/strict_kwargs-2026.5.18-py3-none-win_amd64.whl", hash = "sha256:c90ae750b5754176e943bebaee42d34e51433ead05da60908159b42059ccea75", size = 1983606, upload-time = "2026-05-18T10:43:16.493Z" },
+    { url = "https://files.pythonhosted.org/packages/73/1b/748e7c411a22c26bd8488d4f7b25aaf72c72c2ed68a4e61f0fe802d02136/strict_kwargs-2026.5.18.post1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:72241056a9bf0bfb9c522c5e888ef9868556fa2475890b90f29ae78b837eefb9", size = 2184045, upload-time = "2026-05-18T14:42:59.32Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/76/a3a6fa1082e30fdd8dee750bac496e1595d963e1155572e4ffb3f1cb3761/strict_kwargs-2026.5.18.post1-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:7dea7f9ba8557f57fbf56309735780c1d0b83627f237aeb77f1ee50b7020ac4c", size = 2294579, upload-time = "2026-05-18T14:43:01.989Z" },
+    { url = "https://files.pythonhosted.org/packages/62/75/15f0de12cf822ff2d1a098fdbe70d57c9d262868dfd728d5ea9cb3104234/strict_kwargs-2026.5.18.post1-py3-none-win_amd64.whl", hash = "sha256:eaad5813f39f338eaa3674aec6bf1463fc3ab2ce47f188262592486645d77132", size = 2069130, upload-time = "2026-05-18T14:43:03.323Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add strict-kwargs to dev dependencies and local uv pre-commit hook.

## Test plan
- [ ] pre-commit run strict-kwargs-fix --all-files

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes developer tooling (pre-commit configuration and dev dependency/lockfile updates) with no runtime or production code impact.
> 
> **Overview**
> Adds `strict-kwargs` as a pinned *dev dependency* and records it in `uv.lock`.
> 
> Updates `.pre-commit-config.yaml` to stop using the external `strict-kwargs` repo hook and instead run `strict-kwargs fix` via a local `uv run --extra=dev` hook (`strict-kwargs-fix`), marked `require_serial: true` and included in the CI skip list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2a1e5687c1f4cea7ee84c10e07e90ee165fc3c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->