### PR TITLE
[codex] Add towncrier to release extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ optional-dependencies.dev = [
 ]
 optional-dependencies.release = [
     "check-wheel-contents==0.6.3",
+    "towncrier==25.8.0",
 ]
 urls.Source = "https://github.com/adamtheturtle/pytest-beartype-tests"
 entry-points.pytest11.pytest_beartype_tests = "pytest_beartype_tests.plugin"

--- a/uv.lock
+++ b/uv.lock
@@ -1205,6 +1205,7 @@ dev = [
 ]
 release = [
     { name = "check-wheel-contents" },
+    { name = "towncrier" },
 ]
 
 [package.metadata]
@@ -1231,6 +1232,7 @@ requires-dist = [
     { name = "shfmt-py", marker = "extra == 'dev'", specifier = "==4.0.0" },
     { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.19.post3" },
     { name = "towncrier", marker = "extra == 'dev'", specifier = "==25.8.0" },
+    { name = "towncrier", marker = "extra == 'release'", specifier = "==25.8.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.38" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
     { name = "yamlfix", marker = "extra == 'dev'", specifier = "==1.19.1" },


### PR DESCRIPTION
## Summary

Add `towncrier==25.8.0` to the `release` extra so the release workflow can run:

```bash
uv run --extra=release towncrier build ...
```

The previous towncrier migration added the tool for development/docs builds, but release jobs install only the `release` extra before invoking towncrier.

## Validation

- `uv lock`
- `uv run --no-dev --extra=release towncrier --version`
- repo pre-commit / pre-push hooks run by `git commit` and `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts packaging/lockfile metadata to ensure release installs include `towncrier`, with no runtime or logic changes.
> 
> **Overview**
> Adds `towncrier==25.8.0` to the `release` optional dependency extra so release workflows that install `--extra=release` can run `towncrier build`.
> 
> Updates `uv.lock` accordingly, including the `release` group entries and `requires-dist` markers for the new extra dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38c82fa18e159b437f6fb0de9f1fbdebe3ce6702. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->