### PR TITLE
[codex] Make useless Pylint suppressions fail lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,10 @@ MASTER.load-plugins = [
     "pylint.extensions.typing",
 ]
 MASTER.unsafe-load-any-extension = false
+# Return non-zero exit code if useless-suppression is emitted.
+MAIN.fail-on = [
+    "useless-suppression",
+]
 DEPRECATED_BUILTINS.bad-functions = [
     # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
     # make this removable:


### PR DESCRIPTION
## Summary

- Configure Pylint to fail when `useless-suppression` is emitted.
- Keep existing useless-suppression enablement and project-specific Pylint settings intact.

## Validation

- Parsed `pyproject.toml` with `tomllib`.
- Ran `pylint --rcfile pyproject.toml --list-msgs-enabled`.
- Ran repository commit hooks for the changed file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only tightens Pylint configuration to make `useless-suppression` a build-breaking lint failure, which may cause CI to start failing until redundant disables are removed.
> 
> **Overview**
> Pylint is now configured to **exit non-zero** when it emits `useless-suppression` by adding `MAIN.fail-on = ["useless-suppression"]` in `pyproject.toml`.
> 
> This turns redundant `# pylint: disable=...` directives into hard lint failures, helping keep suppressions from accumulating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d56361551a24aa185a30686893d8f35bcb68843. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->