### PR TITLE
Remove pytester makepyfile pyright workarounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,11 @@ zip-safe = false
 [tool.setuptools_scm]
 version_scheme = "post-release"
 
+[tool.uv]
+# pytest 9.0.3 still lacks the pytester.makepyfile typing fix from pytest-dev/pytest#14080.
+# Keep local uv resolution pinned until a pytest release includes it.
+sources.pytest = { git = "https://github.com/pytest-dev/pytest.git", rev = "fd90f701b3356998fc0562a1fae3c52afcf8e0dc" }
+
 [tool.ruff]
 line-length = 79
 lint.select = [

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -25,8 +25,7 @@ def beartype_call_count() -> dict:
 
 def test_type_correct_test_passes(pytester: pytest.Pytester) -> None:
     """A test whose values match their annotations runs normally."""
-    # https://github.com/pytest-dev/pytest/pull/14080
-    _ = pytester.makepyfile(  # pyright: ignore[reportUnknownMemberType]
+    pytester.makepyfile(
         """
         def test_ok() -> None:
             x: int = 1
@@ -41,8 +40,7 @@ def test_argument_violating_annotation_fails(
     pytester: pytest.Pytester,
 ) -> None:
     """Parametrized values that violate a type annotation fail."""
-    # https://github.com/pytest-dev/pytest/pull/14080
-    _ = pytester.makepyfile(  # pyright: ignore[reportUnknownMemberType]
+    pytester.makepyfile(
         """
         import pytest
 
@@ -59,8 +57,7 @@ def test_class_based_test_is_type_checked(
     pytester: pytest.Pytester,
 ) -> None:
     """Methods on test classes are also wrapped with beartype."""
-    # https://github.com/pytest-dev/pytest/pull/14080
-    _ = pytester.makepyfile(  # pyright: ignore[reportUnknownMemberType]
+    pytester.makepyfile(
         """
         import pytest
 
@@ -79,8 +76,7 @@ def test_wrapper_cached_across_parametrized_items(
 ) -> None:
     """Parametrized items share a single beartype wrapper."""
     _ = pytester.makeconftest(source=_COUNTING_CONFTEST)
-    # https://github.com/pytest-dev/pytest/pull/14080
-    _ = pytester.makepyfile(  # pyright: ignore[reportUnknownMemberType]
+    pytester.makepyfile(
         """
         import pytest
 
@@ -98,8 +94,7 @@ def test_each_distinct_function_is_wrapped_once(
 ) -> None:
     """Distinct test functions each get their own beartype call."""
     _ = pytester.makeconftest(source=_COUNTING_CONFTEST)
-    # https://github.com/pytest-dev/pytest/pull/14080
-    _ = pytester.makepyfile(  # pyright: ignore[reportUnknownMemberType]
+    pytester.makepyfile(
         """
         def test_one(beartype_call_count: dict) -> None:
             assert beartype_call_count["n"] == 2
@@ -116,8 +111,7 @@ def test_same_named_methods_in_different_classes_keep_own_types(
     pytester: pytest.Pytester,
 ) -> None:
     """Same-named methods in different classes get class-specific wrappers."""
-    # https://github.com/pytest-dev/pytest/pull/14080
-    _ = pytester.makepyfile(  # pyright: ignore[reportUnknownMemberType]
+    pytester.makepyfile(
         """
         import pytest
 
@@ -138,8 +132,7 @@ def test_same_named_methods_in_different_classes_keep_own_types(
 
 def test_return_annotation_is_enforced(pytester: pytest.Pytester) -> None:
     """A test returning a value that violates its return annotation fails."""
-    # https://github.com/pytest-dev/pytest/pull/14080
-    _ = pytester.makepyfile(  # pyright: ignore[reportUnknownMemberType]
+    pytester.makepyfile(
         """
         def test_bad_return() -> None:
             return "not None"  # type: ignore[return-value]
@@ -160,7 +153,7 @@ def test_nested_pytest_main_after_beartype(
     closure that crashes when invoked with ``Format.STRING``, breaking
     any subsequent collection that introspects annotations in string form.
     """
-    _ = pytester.makepyfile(  # pyright: ignore[reportUnknownMemberType]
+    pytester.makepyfile(
         """
         from __future__ import annotations
 
@@ -200,7 +193,7 @@ def test_underlying_annotate_is_preserved(
     beartype/beartype#637 fix; on older versions it exercises the same
     save/restore code path so coverage stays at 100%.
     """
-    _ = pytester.makepyfile(  # pyright: ignore[reportUnknownMemberType]
+    pytester.makepyfile(
         """
         def _sentinel_annotate(_format: int) -> dict[str, object]:
             return {"return": type(None)}
@@ -220,7 +213,7 @@ def test_underlying_annotate_is_preserved(
 
 def test_non_function_items_are_skipped(pytester: pytest.Pytester) -> None:
     """Collected items that are not ``pytest.Function`` are left alone."""
-    _ = pytester.makepyfile(  # pyright: ignore[reportUnknownMemberType]
+    pytester.makepyfile(
         '''
         def add(a: int, b: int) -> int:
             """Add two numbers.

--- a/uv.lock
+++ b/uv.lock
@@ -871,26 +871,26 @@ wheels = [
 
 [[package]]
 name = "prek"
-version = "0.4.4"
+version = "0.4.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/13/3d71b3adbf385f7dc7fb6e16d6e25421fd8398b45d8f8410a328bf22bd3f/prek-0.4.4.tar.gz", hash = "sha256:4ec5771153d158a0e4473933b7fd9b51e1b1f57f2df50aeb7560ea6812226dc5", size = 470641, upload-time = "2026-06-04T07:26:07.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/46/e436a6eb9fdb4d3fd08d0ab7fdba19fe03a9e994ec810de57869b853bd8e/prek-0.4.8.tar.gz", hash = "sha256:d15d8bef72ab7b02c7dc01458ac9e05b3131534492b5ce9bb11c4f6f636fa868", size = 494570, upload-time = "2026-07-04T12:05:10.941Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/9f/68a577888edf7f2647a652b02899508ccd84e57ce1f79c51a44edfd308d7/prek-0.4.4-py3-none-linux_armv6l.whl", hash = "sha256:23cfd96a25de1c93e3c43c746643b80489e3b2fa49ca9c0ffd6022e51535c900", size = 5550271, upload-time = "2026-06-04T07:26:17.834Z" },
-    { url = "https://files.pythonhosted.org/packages/35/b8/5427a0023116343a8d787b446536a7fddfa5db7eec7713dd05618da2bdfe/prek-0.4.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a427b792c4436f49732b1f6ebccf221fdcc6390c148474280da9c2c6eaabc9c4", size = 5910136, upload-time = "2026-06-04T07:26:20.616Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/4f/d751e90b7e768e472e054cd41cbe502589436ca9c1a13bfe4fa9513f9cde/prek-0.4.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b998038fc92c990e03147eb5b95b0f2c394517f8857ab911aac8e092f1b9b3ab", size = 5470124, upload-time = "2026-06-04T07:26:29.23Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/fe/e73241c5777b6f9b6b95132febbd27f9be9e89912e9e93c0982680593af2/prek-0.4.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:9cebca8c15da4f1d6e3a25e6ae0611425c8596e926222050f2588c390e42df8a", size = 5732725, upload-time = "2026-06-04T07:26:19.133Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/a3/329bd910e7e5d9d0eb5e571f3ba48023213744e78411afb81f5ef8356cab/prek-0.4.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c8742ac26363e74c855df6215a709d5db183204d00ac0f1a722b13aed4da3cd0", size = 5457953, upload-time = "2026-06-04T07:26:23.41Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/f8/d642990513d9707398506bad45d39173d84266231f7d919899f694aefe2c/prek-0.4.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a2b7c8710546a1e894afa7ab022030cd4e21f1ee7ffb301b4360773d22f1f00f", size = 5860556, upload-time = "2026-06-04T07:26:11.692Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/17/a2e29cb278503a8c18612d8a62a15020648dc768e2e94bc4b4d4c9411e07/prek-0.4.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e02bd4d5e05c500e4d9f70f024e30d13aa361dc490724b7f476d2e35542c239f", size = 6652492, upload-time = "2026-06-04T07:26:09.962Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/10/ad3270b18135ee5d1af6f6cf4b0c8601b1cc2cb38d16e835081da820833a/prek-0.4.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f3a25041733de987a47e5a7bace47182a6f0e2ae5f960cb54c1d4630afd2591", size = 6113837, upload-time = "2026-06-04T07:26:24.873Z" },
-    { url = "https://files.pythonhosted.org/packages/59/d9/e8c201b9b41c4561673cea01c630ab604df89d13e952f87dbcb807d32588/prek-0.4.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0b04a0f36d07474f2a9fc5b1ba1197a1b326b2b211f39cd74cf0d4613545f7f4", size = 5729155, upload-time = "2026-06-04T07:26:26.194Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/cd/227b0494fcbc91e8fe15c2a4db9e6dfff95314ef38db3e40e6ea96db249d/prek-0.4.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:f032ccbe2d6edc345f81a6d772c18cc169d63c27b5a8292bfe416b352bdfee57", size = 5590775, upload-time = "2026-06-04T07:26:22.038Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/e0/9d750b9cf21ece884afdc15668d0f005a36588fe1b0bb5ff4a8112ab51cb/prek-0.4.4-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:bad3586fcea3e913f0edf2e8f132f97889e03976b7ee3d120fd294ad4e89a5eb", size = 5437864, upload-time = "2026-06-04T07:26:30.673Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/48/e2e5c0299590ad18a253c0ac09508b615baa1b382010c511186572f711d3/prek-0.4.4-py3-none-musllinux_1_1_i686.whl", hash = "sha256:4058638532c6dcbf0076d23b9264cbdd9f0f0e320762e237a6b9e4e4b854a766", size = 5718579, upload-time = "2026-06-04T07:26:27.786Z" },
-    { url = "https://files.pythonhosted.org/packages/54/48/7fb3d4e7f664d1ce8ae35ec553872ffddf9fab4c5081735fdaae610b1e7c/prek-0.4.4-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:619bab14071670249777deea0cc0b29d904c4a514cf33b20e583900a544f0399", size = 6231622, upload-time = "2026-06-04T07:26:16.309Z" },
-    { url = "https://files.pythonhosted.org/packages/46/c0/a4ddbf38034afe67cfa97c4bd81c86429ada098e7c323218d9f9fd061566/prek-0.4.4-py3-none-win32.whl", hash = "sha256:143154b329c05b2f9fa3230e604d02d9c4297dd43f96135a8ba166772e8ecd60", size = 5240317, upload-time = "2026-06-04T07:26:08.726Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/8c/fe97b5b095187bb2f93bbe406bccf108c879e5e4c83f165809b0d16ce0fb/prek-0.4.4-py3-none-win_amd64.whl", hash = "sha256:c38c5140ae2ea55ebb02e6ca590a416664ea1af287cdd21f54daeec53a81015a", size = 5626104, upload-time = "2026-06-04T07:26:14.81Z" },
-    { url = "https://files.pythonhosted.org/packages/25/63/3586226d536796e65f8e725b531d6104e55caaa18659bdcb512661629586/prek-0.4.4-py3-none-win_arm64.whl", hash = "sha256:3efa28fb37b9ddbafb7759da8d497f0d36cf02a05816e15d6541f5669d5d2114", size = 5470399, upload-time = "2026-06-04T07:26:13.231Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/78/b4149c8913ced2e42debb49e261c4788a1ce431e84226921c2e1a7ea8545/prek-0.4.8-py3-none-linux_armv6l.whl", hash = "sha256:1f8f8cdc65836b571824c965daebb81b449f7e4a43894c58621f5708d5a185ed", size = 5668955, upload-time = "2026-07-04T12:04:41.588Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5f/7f54a0087b6b2f1751aeb41266d9c15e66fd0055492814798ab818cd0414/prek-0.4.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:bce1798e96d9e3a6e6abf435da7107e81452f69edb3ca7c6f90a457355ea46e2", size = 6030947, upload-time = "2026-07-04T12:04:43.8Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d6/f2829fc3902920c36b764a386fa303e71a8219dac25cb3827c575e84199a/prek-0.4.8-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ab3a52db17254d701c3cebb7eea58c8230aa7c1959aacfd5b5f25de18edb15d1", size = 5572593, upload-time = "2026-07-04T12:04:45.763Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/c5589955bcd5e3e33b67d8bc3110818cecac82a38fd6bc8b5dfdc5de421c/prek-0.4.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:b3fcfd620523bbc3f51a21d7cd63449f659b9e2cf3582de12dd5949e23227b8f", size = 5847150, upload-time = "2026-07-04T12:04:47.419Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9d/1f2dc91bdb79d2c4714b27eac9477a51490fba5b4731330dbbebc76bd345/prek-0.4.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42e65bc8425e9d7f1691a13ca1da2e07807d1ba76c35740833354b945131689e", size = 5573738, upload-time = "2026-07-04T12:04:49.125Z" },
+    { url = "https://files.pythonhosted.org/packages/81/29/69a7b58e16ecbc5f3989bf4b028018d11a82dcdd320b93d6588d72f32aa7/prek-0.4.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f578492a8e0c9bc6b4bf6dfbba8716f647d4cd0769bf10ad6cf336e3096fd392", size = 5981054, upload-time = "2026-07-04T12:04:50.842Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cc/9b9850a60c22ed18c7755ebd2d72c6eefb37fac58149d09f6adc4691c2cf/prek-0.4.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4335f9d5beb123a3884a7fe34f57c9f0828f4fbb7666beab4298833459b104f", size = 6751350, upload-time = "2026-07-04T12:04:52.529Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e5/c425aa7272b430630119e6757def3a2007555ba8cbeb2630e0448e7a8b7f/prek-0.4.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18a8747df9c602e052881d3efb14dd7f7d62a59bd7277ae5171c9e7661d59d84", size = 6243881, upload-time = "2026-07-04T12:04:54.703Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/accd3ad07fd2891d3c2777eb42435439fdf11982c51d60f087c0b6b6e102/prek-0.4.8-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:4db639db481d5f854eff9b3d2108889e613b8c15868bcf6bdd777c7cee577436", size = 5848846, upload-time = "2026-07-04T12:04:56.402Z" },
+    { url = "https://files.pythonhosted.org/packages/15/00/3477704635249f21f5f98ce444cd7690c2aa9dc8d146a045db88ef2cd8c5/prek-0.4.8-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:c3890a6f92316d2cf44eb50584e8d2b23a596dd70487022e61186a71a2ac0900", size = 5713942, upload-time = "2026-07-04T12:04:58.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e6/3ca4fabaebeadc976d9a92d1d9130674265355ea3b728418bad61583b097/prek-0.4.8-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:fc7e15c24c591a37c6ffce5b25a021b16c299ac2649f183d812b67d665cd6551", size = 5554725, upload-time = "2026-07-04T12:04:59.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/46/2ab6aaaeff0cedb8955b2e4032071c8712382bdd423bb849718c3720180d/prek-0.4.8-py3-none-musllinux_1_1_i686.whl", hash = "sha256:36fe721704ff0c7624c1167639e23a5fe658bfd38c314f487219c9afd1eeb733", size = 5838595, upload-time = "2026-07-04T12:05:01.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8b/91398f2b6cd1629d5d8ca8c85b08eca500814a374313b0193f4aaf6ab6c4/prek-0.4.8-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:162e544abc394a8124f3a4ad68efee116bad09440e679dbd1675177335c2a432", size = 6357222, upload-time = "2026-07-04T12:05:03.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2a/ce5cbfaad36866134a21754640a05ecdba641fcd7ad15aa74cf3443f34f6/prek-0.4.8-py3-none-win32.whl", hash = "sha256:2602e46c8c5da7dfa69f60fcf88c2b57132ac623f49fb08bfb3094298c5f07e3", size = 5354388, upload-time = "2026-07-04T12:05:05.587Z" },
+    { url = "https://files.pythonhosted.org/packages/df/03/3bc908bc5f7e430315553e47dfa055f19923a3888f9afe4da19f244b5cbf/prek-0.4.8-py3-none-win_amd64.whl", hash = "sha256:7cb22da60bee41b89c4978c0bea7126a3c0ccc003dae6748cf29b53947815edc", size = 5748221, upload-time = "2026-07-04T12:05:07.559Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a7/4295e6d5f5028171dfeb115ad38ab76bf3fe0c8df91b70d73c79aa760a94/prek-0.4.8-py3-none-win_arm64.whl", hash = "sha256:da70057f577b15d4bd121bf9dd29ee205fd4b4d75a0cafba062e84d7e8b4378b", size = 5574425, upload-time = "2026-07-04T12:05:09.595Z" },
 ]
 
 [[package]]
@@ -1030,7 +1030,7 @@ wheels = [
 
 [[package]]
 name = "pylint"
-version = "4.0.5"
+version = "4.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astroid" },
@@ -1041,9 +1041,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/1d/3bb57f303701549550d74bf7ced2b07412be97125c167a0c9d216aa9f762/pylint-4.0.6.tar.gz", hash = "sha256:52f19191bee08bf103f9705ad1a0ece4aa5a0a4ef2bdcbd969375a1e6f6579d5", size = 1585588, upload-time = "2026-06-14T14:43:26.772Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/da/acb2e7d4dbd2dfb792d38c0d850481f29ad7049b356d23f56c687d35203b/pylint-4.0.6-py3-none-any.whl", hash = "sha256:d11a0e1fdb7b1cd46ec5d6fc78fee8b95f28695b2d6140e5809925f61e32ea54", size = 538389, upload-time = "2026-06-14T14:43:24.873Z" },
 ]
 
 [[package]]
@@ -1060,44 +1060,36 @@ wheels = [
 
 [[package]]
 name = "pyproject-fmt"
-version = "2.23.0"
+version = "2.25.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/a6/6f22eb43c2ae8d151ee51a26313df16ebd6d9e77b34c63f8fd9086f4c45a/pyproject_fmt-2.23.0.tar.gz", hash = "sha256:893215f9d9ac9deab5e549d051db6d6d8b7102724697f8a9870b17895cf6ca9c", size = 278728, upload-time = "2026-05-30T01:49:15.808Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/56/66ca3eaf7c6183b0efa6f247f48808f3a6f32344f5c765ccabc43f2f1b94/pyproject_fmt-2.25.1.tar.gz", hash = "sha256:41160a3ab383ba2bc56ab346bf0e6ce054b8b010a7f788ea41a00a18f8c63ce7", size = 290943, upload-time = "2026-06-25T16:02:19.914Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/3a/c8b83d4b27f0aeb8dedb68c6388b7d05e9e805d85344deada1cefa12abd8/pyproject_fmt-2.23.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:166e614213fa8cd867218261da1147ccc4f3087370fa187b10c3df23153e5b5c", size = 5147067, upload-time = "2026-05-30T01:48:05.04Z" },
-    { url = "https://files.pythonhosted.org/packages/93/4b/a89594d446597721e0432f28688eb0f10a899e4c2f2c9fd6e028748e382a/pyproject_fmt-2.23.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:202b16f7f7ce8ad3aa54ae17a522de8743e5eefd624f03c99960ab58597d6477", size = 4888204, upload-time = "2026-05-30T01:48:07.416Z" },
-    { url = "https://files.pythonhosted.org/packages/67/7c/9672a8e1ad55c7919c10b6575df8bce63cdc332ed572355606bb3f322adb/pyproject_fmt-2.23.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ddb22be85ea040ef453bd97de2827ec3d9a5d2ee1b174cdd9a748ef785ab0659", size = 5044925, upload-time = "2026-05-30T01:48:09.442Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/39/8f99b0e088f88a358105b823379089755c9660da24d037cd0ff5e09d36d6/pyproject_fmt-2.23.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:99d4e4b86ec8d1f20af53f16245a784dff55f03a7e2e5c57874cf562ec2a53f3", size = 5449523, upload-time = "2026-05-30T01:48:12.145Z" },
-    { url = "https://files.pythonhosted.org/packages/73/4a/7c1abb0542e4d528d52b30ddadd745e87a110dae827c0ba8179a4a3df5e9/pyproject_fmt-2.23.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:4f34d510fddc49f523ca59065910c479b3e8343a8d3d32201d3b59b0d788c0bc", size = 5152925, upload-time = "2026-05-30T01:48:14.249Z" },
-    { url = "https://files.pythonhosted.org/packages/40/6b/c9699264d80beae249925393f9afd0e95beaa0b7c9bba69d5b925c0c0752/pyproject_fmt-2.23.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b2e7b92ac9e9d56243b10ffb61a68ea5270494efdac96310bea0996de7c11d97", size = 5040309, upload-time = "2026-05-30T01:48:16.443Z" },
-    { url = "https://files.pythonhosted.org/packages/25/8b/27e344adf8c70137966c5e21b7766255fd8750950ce74540627dcc7c5ab7/pyproject_fmt-2.23.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0346ffb4d77804de68512ce82c3212ded49faedfe2eee6c5c27c2a0be76f23b0", size = 5617312, upload-time = "2026-05-30T01:48:18.62Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/97/fbc02877ebdb14d413ab2a1660ee098d1967cf3bb60a837828f625925eb8/pyproject_fmt-2.23.0-cp310-abi3-win_amd64.whl", hash = "sha256:bbc60a00a599b556ed9ad824a6e541d7f0854848a33d710a413bbb8dfd25d807", size = 5287553, upload-time = "2026-05-30T01:48:20.525Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/72/248d94c639ade7d6aa7e5b03f3cce1d28b597c6facacb5795bcaa8985854/pyproject_fmt-2.23.0-cp310-abi3-win_arm64.whl", hash = "sha256:3ed0e36caccbf3955dbd5a5cc83862b331acb5e07db1ef31e11f647d88dbeccc", size = 4826866, upload-time = "2026-05-30T01:48:22.273Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/b5/cc1d90322e0e376f03083952e1c65ab190cc2173fe2def1a4bddc9f2748a/pyproject_fmt-2.23.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:0a958bbe5be12aa18ad48dcb8b51ce81fabf403121f496d1f0d3c9451a77ffc9", size = 5137403, upload-time = "2026-05-30T01:48:24.353Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/82/c80ca4d5fb881016633f359d0d3f97f64eb1c186a749e9b27a37651b9d32/pyproject_fmt-2.23.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:40f59cf623e57463afeebfc9cd9b3e3691f87ae627cc8096c9f3edd4755fb219", size = 4884077, upload-time = "2026-05-30T01:48:26.789Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/22/f8e90dfda84449ec92f3494baf0cd98e7452754c8831fe143143a6895253/pyproject_fmt-2.23.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:b1fb0f5cf73e020a773a32950a496293141facfb0f918bdea54d31f1d78bb466", size = 5040761, upload-time = "2026-05-30T01:48:28.762Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/9e/0ec445447f691e60fb35e6809e563c9231a5173f5761a0f76f566d713e89/pyproject_fmt-2.23.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:83d0569e24891f1e19dbbe305475a294e1e04f7ebe3578286c5fb07cf763d79a", size = 5442187, upload-time = "2026-05-30T01:48:30.954Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/26/2de5e89a8a6e7f4bae66e917bc6d3e112f4e6e14c5bf3c7dd923f14c3c7b/pyproject_fmt-2.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:73a94faa18917d0103c6cb228b419484ca1d0b58a786909f8b21f0a15791ba32", size = 5036165, upload-time = "2026-05-30T01:48:32.815Z" },
-    { url = "https://files.pythonhosted.org/packages/19/fd/58d24235e4e661261f1118bb994458891a01e2779098f3d0d6c089e6b7c7/pyproject_fmt-2.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6565c7bf05ed3a737ab0ab41fd18c33c9c7ea03f049a0a2558135dbe17d72d9e", size = 5612303, upload-time = "2026-05-30T01:48:35.135Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/f2/c83b2fb7a58e02fc90af4af1f2b7ffc08ab351dbbe1965c620b3ed32ff5b/pyproject_fmt-2.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:25e01dc6876fe9da0c0380f291c7234685e3214431b2dac6cc2bc62d1f896244", size = 5289697, upload-time = "2026-05-30T01:48:36.87Z" },
-    { url = "https://files.pythonhosted.org/packages/65/58/5a217161be7f7c2723fc6ccd70b249bfc1a7dea9f0acab103f7068f34c77/pyproject_fmt-2.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:e5000e3c5e0c93748e364ddeb228710c8052862f1aacfad475f0497f4f5f73cc", size = 4824665, upload-time = "2026-05-30T01:48:38.954Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/0f/5089ddf3e06765711d24a2d031cc658a84ce658bbb02ae3117b7c33501fb/pyproject_fmt-2.23.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:9bff7f42f699a7d7ae4cfd9f7c0f3638998a2d6313cb05b24de8e7e8c47a185a", size = 5138341, upload-time = "2026-05-30T01:48:40.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/5a/2abff23b627b50c222e383efa83bac5b17be6895cb7ab2628b12a56e59e7/pyproject_fmt-2.23.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ebadbbc634ac381ef9fe6c1b9fbbaa1e393e81092249e151065a44e9fa80c322", size = 4884748, upload-time = "2026-05-30T01:48:42.975Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/f2/b56f647a3f2c52c6402e07bc99776e8dbc7bf52a6d6acd9e4f209ab5c438/pyproject_fmt-2.23.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:1177acf2c5e5d99d8a1bf5227036c91ab347e39cdd42a11068b3162b825c7215", size = 5040023, upload-time = "2026-05-30T01:48:44.845Z" },
-    { url = "https://files.pythonhosted.org/packages/af/68/03816e736d8b90a2872028db4439497c1893d3d5cbfc80507b30dffdb5a9/pyproject_fmt-2.23.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ad0901a7aeff0ad11c382152ce5bdccfd8103c85349526eb194cd976d38b0bca", size = 5444604, upload-time = "2026-05-30T01:48:47.17Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/d0/0611ad78ed69bacfc9eef385f6ba48869f8c62f8f0c0c9fda0db1b2edf04/pyproject_fmt-2.23.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7803f35c636591220f582bd3ffb555acfc9d86ca82ec08ce10623d0d57550de2", size = 5035994, upload-time = "2026-05-30T01:48:49Z" },
-    { url = "https://files.pythonhosted.org/packages/68/1a/8be4ec2d1e87d42f85cfa1ed0163c61af07a4d22468513d79e88ea1a6127/pyproject_fmt-2.23.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:623354f81291bc884e81069792955193679a0af43d4cc1cf1af59d1eb5fa7386", size = 5614329, upload-time = "2026-05-30T01:48:51.16Z" },
-    { url = "https://files.pythonhosted.org/packages/17/f2/461632330e991f73abfb6f62fb280a1a4d49a38fcad67ac395dd90570001/pyproject_fmt-2.23.0-cp314-cp314t-win_amd64.whl", hash = "sha256:32b299d5ee2bb5752da558dd475e44726e956111ec18c7bf16cba8d050d211b0", size = 5290888, upload-time = "2026-05-30T01:48:53.662Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/71/0ad901972d9e810aa086ee10c9c4bd96aab08c9e71ec3e2cb9cd7a83f303/pyproject_fmt-2.23.0-cp314-cp314t-win_arm64.whl", hash = "sha256:7e0813432ac38e55b94f24956e51d91fc340310adbc3b96c8cfa751df31d1404", size = 4824667, upload-time = "2026-05-30T01:48:56.253Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c9/00843579b5db4b41f12042c2f09191768439121b645ebae0cca66e7e4b8f/pyproject_fmt-2.23.0-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:2df4d1a3ead6f235cd208f454b0bab0656e693cebed332612526148f7ee21324", size = 5138351, upload-time = "2026-05-30T01:48:58.255Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/c1/fbd07d5b4ae9daceb19c7ee39488c4b55d57026699e30a35ab6d561b6c0a/pyproject_fmt-2.23.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:74153f08e64651206286efc6871c4da8c89360ca7f8651fe5c92cb6385f83ed9", size = 4884297, upload-time = "2026-05-30T01:49:00.1Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/ab/0ecb8739125185a8cbb51fca6c7b1b74e65de09f2d8be0f8619f00ef777c/pyproject_fmt-2.23.0-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:c8c9cea05fbbfe7cf2be3ece0a1cae75da1ea6a0982766abf83044427ceaa26d", size = 5040815, upload-time = "2026-05-30T01:49:01.953Z" },
-    { url = "https://files.pythonhosted.org/packages/59/94/adf908f952c9c5ea298623bc29a6727347a90fc48fdcdde9cf2215c50e1a/pyproject_fmt-2.23.0-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:6b8d40f0b13ac4ab1a5a07f02d85df4553810201db77fc675eb61358f414d937", size = 5444585, upload-time = "2026-05-30T01:49:03.849Z" },
-    { url = "https://files.pythonhosted.org/packages/47/29/bb29305786ce9c71c51774292e268d12aa3c2ba090bd594440bcf1518f37/pyproject_fmt-2.23.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:7568110e8f51b29bed840aac910c03ac2087b8f6ee7a2254d0da25aa3fb59771", size = 5034655, upload-time = "2026-05-30T01:49:05.663Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/19/580d53421d10e14fda60796c3c7ee43b06cf688455d874607c5da076f46b/pyproject_fmt-2.23.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:9cee010e37fd81f9d7a81663d822b495c5044397eaa4ccedcd983c46cf50377c", size = 5613689, upload-time = "2026-05-30T01:49:07.357Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/b6/a656778bb9207f27f63359071541aa7f95cf7369afd88343d76b869c7dbd/pyproject_fmt-2.23.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c9b7c605974150a14e1fe569432c800933aa189e6ef5e0e22bb172d989c0223e", size = 5142713, upload-time = "2026-05-30T01:49:09.397Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/2f/3f6b7780b61ff5e574f0f0e5bfbbe08aa9547a2e13f80e5fd153a2ede626/pyproject_fmt-2.23.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:747b3f1900a4e45ea6f9a0bbaea0d01be9774ac178906ddd2921573062071f26", size = 4887678, upload-time = "2026-05-30T01:49:11.437Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/42/a30cd197997f651c682b67496f66551aafe2b0fa39db012b799a6bca7108/pyproject_fmt-2.23.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:15ce14cac13a54d17aee8e04eee6661e380155eb3da9c14e8b2455b85a56af68", size = 5447014, upload-time = "2026-05-30T01:49:13.671Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/dd/26fff2c140708ce7316569039e55dd3865e1d65902de1617fe2dab752f27/pyproject_fmt-2.25.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2f6d36596282b3b41800b16793b187cda6e01f0c7fd287301bebc8ae4a15e7fa", size = 5161605, upload-time = "2026-06-25T16:01:27.069Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/64/611018334139d7205c33e1850d3bb094d63b6f6d59aac152534c1ef91682/pyproject_fmt-2.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:ef9f2d586a96ab104b96662d6c1ea1cb1b0cade30dcb2b6b25b446847c05eefe", size = 4933533, upload-time = "2026-06-25T16:01:29.665Z" },
+    { url = "https://files.pythonhosted.org/packages/51/14/7a2b21e6aa2ccb7187c4f4d2884d93f1d45ff14929cf42edb4c2f6a09878/pyproject_fmt-2.25.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2d0742970fcf36369d2365d266b7412064b899f9b6be6cc89f5f77729beb3d82", size = 5089342, upload-time = "2026-06-25T16:01:31.596Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f0/017370c155951d52060b31f4bc63e8e69d4a106387dd92bdc7db88ecdebd/pyproject_fmt-2.25.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d495cbc8902dfae61763e21bfe760c3e517fcc2b5f108d0c48f4b5849bc1c60", size = 5480072, upload-time = "2026-06-25T16:01:33.459Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/73e48d71ed78bb1e035d586fc367d7cb69edd5f471fd8e954e9b6128b822/pyproject_fmt-2.25.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:d7f4525b10a284cfd6421e5a9b0e844330a79a81df1c035c4b61bc13560d1932", size = 5195825, upload-time = "2026-06-25T16:01:35.614Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/35/4b3fed602ad1d55901d32aaa007d8341a1cea4112a4369f707f5bb3e7efb/pyproject_fmt-2.25.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:58a4eaeea7caa821ed6f81d4e40dbaf85cb9b2316f088712acfcc9e9823d6cbf", size = 5088192, upload-time = "2026-06-25T16:01:37.442Z" },
+    { url = "https://files.pythonhosted.org/packages/47/0d/2b3a9d68f008f232991980cf506fa71cd1deec6e8cb755f11b7d9e2db72d/pyproject_fmt-2.25.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cba7a32ba173be7e49440e7319e8d68d3b22fa57da7949d1732661ed30dce85", size = 5650122, upload-time = "2026-06-25T16:01:39.176Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c8/4fbea2a4a8a47f7cb24ea3b33b27c8713da6330b92796347648d37c3d38f/pyproject_fmt-2.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:b0625c02a5f9726ddeb056d65047062fa4c19897491a3345d827500d35bdbb8d", size = 5322803, upload-time = "2026-06-25T16:01:41.094Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/18/b47fb4b62a4a7554a591d00d932888e108ca7bb3f477ac108a1f791fd843/pyproject_fmt-2.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:c8ea518ef950a933f20d0c57ccd5c1fec418c53489d9b4ae9a1d5f2a841b0c6c", size = 4855071, upload-time = "2026-06-25T16:01:43.072Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/93/2a51b47b327076a54a15727c7a30b0298ad4d604f5a6d1d0dd4800a9cca5/pyproject_fmt-2.25.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:4cd1b99de1019b25e6b74d4b204999f482cbf256057c67999c7f53a8685a55cb", size = 5161863, upload-time = "2026-06-25T16:01:44.814Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/3debdfd5717f9fa2b43b58dd244eaf57d817cea47e3e8ffb37b67c694c03/pyproject_fmt-2.25.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:217e2536b1e0e6df0504d6271aa3d267e4d9b7a09db0669d97698a30e9add089", size = 4922394, upload-time = "2026-06-25T16:01:47.214Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/65/803d199717235483346b55c0da8b719775fb3582cbb9fafbab5841ad7982/pyproject_fmt-2.25.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:cd42e27372deaea410f1dfea892a256eb888b791fe5f1f62eafb0ee518940149", size = 5085125, upload-time = "2026-06-25T16:01:49.403Z" },
+    { url = "https://files.pythonhosted.org/packages/74/3c/80a0114429d68b38188bd9c55833d0f0227a0c47cb79720aca83df30de2c/pyproject_fmt-2.25.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:93e1cf9979aa48d4ac545db3b08dbd54c1d66abb0f5170a4ac6de95557d2e703", size = 5472289, upload-time = "2026-06-25T16:01:51.216Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/4d/9e0862b830b7fa09a5d036d399e2ae2eb69cf2bc80fb7fb282cd0b1a115b/pyproject_fmt-2.25.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fc2f7888908a8ffd076b5fad71f37afebe5e3e26acb8e2d6e281f57e3daa3b2e", size = 5084394, upload-time = "2026-06-25T16:01:53.005Z" },
+    { url = "https://files.pythonhosted.org/packages/78/8a/24f26269d7f88e1db904e9471ee97bd0ab8ffdc04cfa23727d4af9dd2d4f/pyproject_fmt-2.25.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d4d0aec4f1a1e1b4f4438cda6a30b84e16ab915239bda7041a6f160713ab46bf", size = 5645545, upload-time = "2026-06-25T16:01:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a3/9fc0d64f401fb6317c68ef0949ad0afd3db3c1085e452e3deee18770fead/pyproject_fmt-2.25.1-cp314-cp314t-win_amd64.whl", hash = "sha256:bd2c731c94d85867d27983cf670b3e0ab36ac1b2fbb5d92fcbf43540ff75ce13", size = 5319962, upload-time = "2026-06-25T16:01:56.774Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/cb/1defeb509a684dd3ccc459821764757591e63051b812efaf59d2e5860f85/pyproject_fmt-2.25.1-cp314-cp314t-win_arm64.whl", hash = "sha256:9fe7b320321aa47540c0cfff9b622bc54b6493e67ce16ad9b6160088a95799a5", size = 4848007, upload-time = "2026-06-25T16:01:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/91/dd/81c4c988ca540c90cf1a1729926b9362ee772039be62d8b4d48c374e9ad7/pyproject_fmt-2.25.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:9aa33cb3de02b4758f8b079eab03106d7f36980c6917e7880b97115d4d5df3f7", size = 5161561, upload-time = "2026-06-25T16:02:01.09Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2c/a23b09f18db16e6a36033a7c31230c2423ed3177e9d7bd4042a41de47fa2/pyproject_fmt-2.25.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4abbb263f9f29c70026f064c0a1133d2439f0cc18d73ee6d2b36793fb150ef60", size = 4922490, upload-time = "2026-06-25T16:02:03.243Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/bd/ce5e011a3883fcde61e14341d7534f2250bce04713d3b12b7c6ba3817d48/pyproject_fmt-2.25.1-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:ce81ec7fef5bd7ef4fccf5b679008b92118d54fdd6c4d607de9f30a16896368e", size = 5082287, upload-time = "2026-06-25T16:02:05.395Z" },
+    { url = "https://files.pythonhosted.org/packages/43/85/04556f029896ef804d8ac6c17d198003e11e08db1bf43822006eaf281aa7/pyproject_fmt-2.25.1-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:295f127219ea8ee4c9cf28c586a2adcbd0b9e9df3f2c9a3d391dca51f3b7d640", size = 5474861, upload-time = "2026-06-25T16:02:07.647Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/64/a3af8d289907d36cfc08a76e727ff39f0fb92d11902340d6a9250577cd40/pyproject_fmt-2.25.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:7883414444b67a36b916091de5575067f2b83c85ecd09fd030ed5354ec8159e1", size = 5083034, upload-time = "2026-06-25T16:02:09.912Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/80/ba4f3c3be7106dc9ac8f8c8ac3c460d9c285592c5a6dfcfd75a3446e2122/pyproject_fmt-2.25.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b99217d863e1c7e9253cea27ab1c9b28b46d44553f3e8d36b482ef4e8712de5d", size = 5646115, upload-time = "2026-06-25T16:02:12.214Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/30/300fad34ef4f0b7f2e8e5bc03f50d990fff876d75c03f097cd0485652a12/pyproject_fmt-2.25.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:84d4320e0f07728cdce7c25c5abbd468bbd8b4a2d17188bfc50ae5d7418f3d03", size = 5159497, upload-time = "2026-06-25T16:02:14.152Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b2/e544eb9dd967bff56f85a9c508a6ec97c45fb14698203a5eec2e640f15a4/pyproject_fmt-2.25.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:5749ce0bea4a86c7a13543528171646e2773b042ac6f34a39aedaf828e7536a1", size = 4930844, upload-time = "2026-06-25T16:02:16.318Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/67/2f6cf7765232c970ac8b27f876ea484a5b9378450209b1d8952440c70d35/pyproject_fmt-2.25.1-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:4d1c7b732438e9284aff983983e3dd9bf39173823b6ada97da540f15e8c6b521", size = 5477224, upload-time = "2026-06-25T16:02:18.291Z" },
 ]
 
 [[package]]
@@ -1111,32 +1103,34 @@ wheels = [
 
 [[package]]
 name = "pyrefly"
-version = "1.0.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/3a/9045b0097ac58979c7c30a4fa0e673db942d4adbc7b6d439bd54ae58c441/pyrefly-1.0.0.tar.gz", hash = "sha256:5c2b810ffcebd84be71de5df1223651edee951653a66935c6f091e957c452455", size = 5677995, upload-time = "2026-05-12T20:12:46.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/20/976165fa4b1517a1a92f393b3f4d4badabfff1165eff09d4cd4908428183/pyrefly-1.1.1.tar.gz", hash = "sha256:6deda959f8603a7dbdf112c48983e2275b2903cf33c8c739ed65d7e71a4fd520", size = 5880491, upload-time = "2026-06-18T23:45:43.785Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/c6/90788819bac9c61dd7bacba53b79f3c12d47ccbe5e51b3d6d89f2387e1d2/pyrefly-1.0.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e355a0908555348ed4b9585ef25c76ff566673e345c866c325f1633f44d890b6", size = 13122950, upload-time = "2026-05-12T20:12:20.711Z" },
-    { url = "https://files.pythonhosted.org/packages/82/91/a3cf2a1e87d336eaa804a1e6fc93266faf6dc2a97eecdbc7eae289628022/pyrefly-1.0.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a7038efc3a40f8294edee339895633cf22db268c0d434cdbcbefc34f78a9ecc3", size = 12599494, upload-time = "2026-05-12T20:12:23.495Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ab/74d1e11e737e99b1c003ecc5d7d2e846c4ea1f328966bfdbbd0ac63fad0a/pyrefly-1.0.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da331ca515ed1c08791da2b5f664cf9c1294c48fd802133262e7d5d51e0f4416", size = 12995507, upload-time = "2026-05-12T20:12:25.951Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/ac/2df0899f8464c97e5d995f994c97c5cb5b0f58610432aa90d26d924e1db5/pyrefly-1.0.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c74219d8f3e63cdaa5501a0b21d1c9d37011820f9606728d0ed06f09ae86a878", size = 13947693, upload-time = "2026-05-12T20:12:29.188Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/3e/b247c24321e36f04b7d51f9ccf3df93e5009e4b29939524b36ec2e17dc2a/pyrefly-1.0.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c0d05543b1bb6ee6d64149eb5d6b2fb15aa72d3962d6a97abca0afaca8b0c131", size = 13925803, upload-time = "2026-05-12T20:12:31.904Z" },
-    { url = "https://files.pythonhosted.org/packages/61/16/cfa2d61a4aa1e1f7bca48bb37acd01c6a09db4864b16a54f9587092765ff/pyrefly-1.0.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1382d5b1fcdb49a4de9f34d112d2bddf290a78ff93ee8149492ad5f1077ddffc", size = 13470398, upload-time = "2026-05-12T20:12:35.302Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/2b/6372c7dddb326223e24a46b17efd0d4bd7b4fe22c821e523157577eed2d2/pyrefly-1.0.0-py3-none-win32.whl", hash = "sha256:aa8b5d0e47080e3202a2547b39f7a5a61d2c781c712b3b67884f745ca2c759d2", size = 12222643, upload-time = "2026-05-12T20:12:38.618Z" },
-    { url = "https://files.pythonhosted.org/packages/be/ad/1d23be700b6b2ddaeb362360c7145917a8edbbf7240ae428d40541772fce/pyrefly-1.0.0-py3-none-win_amd64.whl", hash = "sha256:c8abcb0f2082e83c890375128f9cff4aa4d3f210b85eea7b3046c1ae764e77f5", size = 13146369, upload-time = "2026-05-12T20:12:41.423Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/38/16589134f3012fd097a10dcc85771555f1a5fb76e04b682597180743af30/pyrefly-1.0.0-py3-none-win_arm64.whl", hash = "sha256:d150fa9e40e8392832be81c3bcfc0497c146674ce4d0f8e04e1ec29e775ffb8c", size = 12538326, upload-time = "2026-05-12T20:12:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d6/02ba666018c6a1cb4ddfa2db98ada721adddd374db5c29ba47a0bf2637fa/pyrefly-1.1.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f4b8595f91885bc8b5e3c282ab68d1df21201668a84e6508b1e15f2feec0bb8d", size = 13631867, upload-time = "2026-06-18T23:45:13.923Z" },
+    { url = "https://files.pythonhosted.org/packages/71/47/7a3457dbbddb513a83cf4fe527d5d5ebda5201a1010ad2a6034030e3e358/pyrefly-1.1.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d6b238e1362622d47a6eb5af704fd8b613c94e8c303386efd6350e3da59fecc8", size = 13075304, upload-time = "2026-06-18T23:45:16.865Z" },
+    { url = "https://files.pythonhosted.org/packages/84/df/70f4b3f42d58ed686a80df31e04eca54d88036cea4f9b96195c64ad0b2b5/pyrefly-1.1.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b50d4510e4f8aaea79e2c4b343a4d7a060c9451c0b2aa9bfe10d7ca1ef33d68d", size = 13446966, upload-time = "2026-06-18T23:45:19.644Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/53/12a19bd6c7af985bcbc13c6910d0f9f6684069ead2282a5c08c2bfbb5d03/pyrefly-1.1.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f330cf039ef3da3b910c84f3a7e431f0cf8d0c1d2dad26491d6cadf3c7cd4759", size = 14449222, upload-time = "2026-06-18T23:45:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f0/e55c48a50076fc0f9ecf4bdedec50456db383e01162f5e2121f8468be071/pyrefly-1.1.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a6342d87c52b04f72156da04f554c4d57f3616f2b32d1763969efb22d05a1407", size = 14472947, upload-time = "2026-06-18T23:45:24.858Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e7/30e085b31fed978ecb675bdbb54df566673ab550469e5af2d350f6af0be6/pyrefly-1.1.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c08b814ad03175e9cf47111390537161828b472044c39ab3320252b3ac6b2edd", size = 13975252, upload-time = "2026-06-18T23:45:27.247Z" },
+    { url = "https://files.pythonhosted.org/packages/47/58/49c3e67641133d3fe5d8d9a660dc0826c6c37ca197d86cad05fa7dd8bfd6/pyrefly-1.1.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d50cad97f19fc893b04deff7239626cffff5dd27ffb29b7d303a1b770247b208", size = 13471780, upload-time = "2026-06-18T23:45:29.775Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1e/65a7ba8355e2c39d8331832905fb74dcc85fc122a3f1dfd6dbf2a88907ad/pyrefly-1.1.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2150b450ee6a6bcbe69b2d45d9a4ebc934a609e1abcf65e490433f38eb873d84", size = 13989306, upload-time = "2026-06-18T23:45:32.576Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/b7ee1ab2392c36945738246fba7524439810befa3cfcc03cb6157567fc10/pyrefly-1.1.1-py3-none-win32.whl", hash = "sha256:5ffd8a8ed62fe4e6bf0afe1837d1bad149bb3b9f80e928ef248c96b836db3742", size = 12608469, upload-time = "2026-06-18T23:45:35.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9c/a0f5b52934bf80e9c7eff08222e7caf318287b9aef76acb8d9ac5740581b/pyrefly-1.1.1-py3-none-win_amd64.whl", hash = "sha256:4e0430f3ef69c8ac73505fd6584db70ed504665a9f0816fef7f723de510f26cb", size = 13502172, upload-time = "2026-06-18T23:45:38.375Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/4c6bcb3d456835f51445d3662a428f56c3ea5643ec798c577030ae34298c/pyrefly-1.1.1-py3-none-win_arm64.whl", hash = "sha256:83baf0db71e172665db1fca0ced50b8f7773f5192ca57e8ac6773a772b6d2fc5", size = 12895979, upload-time = "2026-06-18T23:45:41.026Z" },
 ]
 
 [[package]]
 name = "pyright"
-version = "1.1.410"
+version = "1.1.411"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
 ]
 
 [[package]]
@@ -1159,18 +1153,14 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
-source = { registry = "https://pypi.org/simple" }
+version = "9.1.0.dev397+gfd90f701b"
+source = { git = "https://github.com/pytest-dev/pytest.git?rev=fd90f701b3356998fc0562a1fae3c52afcf8e0dc#fd90f701b3356998fc0562a1fae3c52afcf8e0dc" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -1222,25 +1212,25 @@ requires-dist = [
     { name = "interrogate", marker = "extra == 'dev'", specifier = "==1.7.0" },
     { name = "mypy", extras = ["faster-cache"], marker = "extra == 'dev'", specifier = "==2.1.0" },
     { name = "mypy-strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.5.20.1" },
-    { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.4" },
-    { name = "pylint", marker = "extra == 'dev'", specifier = "==4.0.5" },
+    { name = "prek", marker = "extra == 'dev'", specifier = "==0.4.8" },
+    { name = "pylint", marker = "extra == 'dev'", specifier = "==4.0.6" },
     { name = "pylint-per-file-ignores", marker = "extra == 'dev'", specifier = "==3.2.1" },
-    { name = "pyproject-fmt", marker = "extra == 'dev'", specifier = "==2.23.0" },
-    { name = "pyrefly", marker = "extra == 'dev'", specifier = "==1.0.0" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.410" },
+    { name = "pyproject-fmt", marker = "extra == 'dev'", specifier = "==2.25.1" },
+    { name = "pyrefly", marker = "extra == 'dev'", specifier = "==1.1.1" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.411" },
     { name = "pyroma", marker = "extra == 'dev'", specifier = "==5.0.1" },
-    { name = "pytest", specifier = ">=8" },
+    { name = "pytest", git = "https://github.com/pytest-dev/pytest.git?rev=fd90f701b3356998fc0562a1fae3c52afcf8e0dc" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.16" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.20" },
     { name = "shellcheck-py", marker = "extra == 'dev'", specifier = "==0.11.0.1" },
     { name = "shfmt-py", marker = "extra == 'dev'", specifier = "==4.0.0" },
-    { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.6.4" },
+    { name = "strict-kwargs", marker = "extra == 'dev'", specifier = "==2026.6.8.post1" },
     { name = "towncrier", marker = "extra == 'dev'", specifier = "==25.8.0" },
     { name = "towncrier", marker = "extra == 'release'", specifier = "==25.8.0" },
-    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.43" },
+    { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.56" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
     { name = "yamlfix", marker = "extra == 'dev'", specifier = "==1.19.1" },
-    { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.25.2" },
+    { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.26.1" },
 ]
 provides-extras = ["dev", "release"]
 
@@ -1300,27 +1290,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.16"
+version = "0.15.20"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
-    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
-    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
-    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
-    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
-    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
-    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
-    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
 
 [[package]]
@@ -1381,15 +1371,15 @@ wheels = [
 
 [[package]]
 name = "strict-kwargs"
-version = "2026.6.4"
+version = "2026.6.8.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ty" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/a4/3a844da9fc063c0820915eabfdd4e835b96d531ecdd8328f274b74ee577e/strict_kwargs-2026.6.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ae9c6216795d5d0d860c07cd8922e14fd0475d08ae161acc39e1f86502254c4d", size = 2773540, upload-time = "2026-06-04T10:50:49.565Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/87/abe98cae04bc7991ad895e3f0faa53d51fb4b3fb81ee11f5b049406257c4/strict_kwargs-2026.6.4-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:6a3ebe5442ad94a6fdee04d42bce30a2c05fefbaa484fc2000519ce8b5f6e150", size = 2934887, upload-time = "2026-06-04T10:50:51.168Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/f2/781b0e2fc45552f1fc860c68daa0dcbae18c758089061ad096cf53b2a4f3/strict_kwargs-2026.6.4-py3-none-win_amd64.whl", hash = "sha256:3b64d47ac7514c8e54d058fad340b2230b32253ac102f4035c23f04d656905b6", size = 2648814, upload-time = "2026-06-04T10:50:52.507Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/be5a8439df38f15ee00a93caf95b498ca2b379a73840e660c60d7eee10f5/strict_kwargs-2026.6.8.post1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9856da92bef457ce912ebf42c7b54b25d94323729e27a3f3cf22c962b3c01922", size = 2800497, upload-time = "2026-06-08T19:00:06.426Z" },
+    { url = "https://files.pythonhosted.org/packages/67/34/b28fac9d41ae163636b60b0df96c759b909f16c5c335c79cafd0d5572388/strict_kwargs-2026.6.8.post1-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:dd0e2c01f516accd748f51a103ba04b162010bdec4c869df8a16392104d9507b", size = 2963053, upload-time = "2026-06-08T19:00:08.414Z" },
+    { url = "https://files.pythonhosted.org/packages/33/92/b70c922af8a0da6ea134f0b67dbf590142995c331eecc3d5addbfa0d73ec/strict_kwargs-2026.6.8.post1-py3-none-win_amd64.whl", hash = "sha256:f515f25fe06b6cb54527d22e2b86a6811bb11617a8f12754318b1c775ff06dc2", size = 2674523, upload-time = "2026-06-08T19:00:10.171Z" },
 ]
 
 [[package]]
@@ -1488,27 +1478,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.43"
+version = "0.0.56"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/37/4ec04de0659b93be37d956dfceca13b1ecab9c959f28d8a1d5e514603f36/ty-0.0.43.tar.gz", hash = "sha256:ea4cff50548f2a1877e848d3abe9e293cde8ab94757a7eb93fc0d4013f98be8e", size = 5798429, upload-time = "2026-06-04T00:52:10.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/07/fb29aea5235b0aa8ecfc4d1cc6ddf9fba8b863d67d96c6d345694d644c43/ty-0.0.56.tar.gz", hash = "sha256:84d114dc3796361c0fc72945016eabd74d46b9ee64f198cb0e485719704681e5", size = 6050123, upload-time = "2026-07-01T16:44:56.036Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/74/1916026a78f20019a2f03adbd6fb4430ddb7ce1e52c2e17a90856a6d192e/ty-0.0.43-py3-none-linux_armv6l.whl", hash = "sha256:3bf70f5446480562bf6c9f639df4b5cb60716b8f8d1a6b8e5811d5c7eccd8bf2", size = 11598153, upload-time = "2026-06-04T00:52:20.646Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/af/58bb0089d2635216c8fa6612dd486a3f986d0ab1c46a41527ab95e57f0e3/ty-0.0.43-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7184741f8b15425a1bc64b950ad005cb353573288ac0e8a04f5481ceb3832596", size = 11357811, upload-time = "2026-06-04T00:52:24.683Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/9c/32c6b14f3feddf87b59c7a50709e2b3da408258f2f583f05575f77bc8f7b/ty-0.0.43-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8c306379ca9a35f6ae5270fe9bda7af4b46d91822725a2586d78c8b9b5493b62", size = 10772024, upload-time = "2026-06-04T00:52:14.312Z" },
-    { url = "https://files.pythonhosted.org/packages/09/fa/98aa4a74bd00cd5efc424923cd1daffbf1e40a0338041cafb203379d746f/ty-0.0.43-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d624b884c9c1fd244ad2a5f026364e7162a22b3f537025941ada2e363e676414", size = 11291034, upload-time = "2026-06-04T00:52:37.249Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/db/4de086c38ce96dcada2bd451f43171d2c237f96d8ed19a1ea8fe51bb8ef4/ty-0.0.43-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:281fc4c00fbc196045141faa085055bddc58846b04a2800204701415a1b9c6aa", size = 11364724, upload-time = "2026-06-04T00:52:33.138Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/d3/e3cd8e3233a6fd8362a49aa025b79e9f40151a2a86d811ace154c6eb7445/ty-0.0.43-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f57d6cc28de89024b48d1788e4758c05299d5749d4a51c02e71ac655ec23d9a5", size = 11890555, upload-time = "2026-06-04T00:52:22.711Z" },
-    { url = "https://files.pythonhosted.org/packages/80/7b/6f46d444e8241606bbde098df3dca93f2ec0b834a42055db85ee7d33646f/ty-0.0.43-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0a1d6ad6c5e7792c7eac0a01e550f2c2004462e01a64a91ea1636aba6fef6e71", size = 12450968, upload-time = "2026-06-04T00:52:28.94Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/e1/79fbe51f2e4b9d8347f2013cd7ed0b63f3b499038c02dc0357e9b28a3a47/ty-0.0.43-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:66d474395d7635fb618bdbb58b4e3360259a2056d0a5621b82754b9da2cd8a04", size = 12064187, upload-time = "2026-06-04T00:52:12.039Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/3f/c758a3a8df5b90d331f2b60c8f16021ee64d75e78f99d67cc4efc9bf5f4b/ty-0.0.43-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2663a0003a8b60fb98db7f6f6e673df80b21d0fe3a9868a26fb06b4e049b6fc4", size = 11943208, upload-time = "2026-06-04T00:52:31.14Z" },
-    { url = "https://files.pythonhosted.org/packages/54/5f/f516442749cf1b45ca6720a5d41df2738a486ed9ace774c03d515db89084/ty-0.0.43-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:d5a6c352d374d889189d5ec82b54b26a5885f769f7b7787f7f875500dcb8673e", size = 12143572, upload-time = "2026-06-04T00:52:18.457Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/bf/0d83c7f43bf4c10f3678bfe7d938e51c445298c7b923f155c5204730c2df/ty-0.0.43-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e7dbbeedfad3ca250d74fcc355fa9ab6b38d2a17f22d6304f615716939dbbb27", size = 11279355, upload-time = "2026-06-04T00:52:26.726Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/de/a6c978bef6d9e949f79f4782d9e4ee4df0893713e73b055d84c1a5116b9a/ty-0.0.43-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:24b18a0273ee46154996cfcfa27438f851f440c925587ec200df6f98dffe67d3", size = 11408412, upload-time = "2026-06-04T00:52:35.282Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/b1/d13857c23867f0f76b92e38e5841c64ca5e76dc5d4bf27f52cb81d8ab685/ty-0.0.43-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2ef681951520d692b7e9c0b5e56aacf4f98ccae47cf6ffccaf2c7b6b33dc226e", size = 11541709, upload-time = "2026-06-04T00:52:16.451Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/f1/cd6afc6f6a687e238bf5e12189f7920e81a0bdef6c3dba4c784ef140f7d9/ty-0.0.43-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2af105de7437143aa4676b28016b5bee661aaaa4eff52be5867fb25119641ceb", size = 12041266, upload-time = "2026-06-04T00:52:43.541Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/ba/51ca7c3335da2b8d0a3e477fa4986be9f4a53b05bfab862967d8d2e6ca60/ty-0.0.43-py3-none-win32.whl", hash = "sha256:e4773115b0d6486ee30f1657fc8bdffe7e3a3f5300ab77ef2495da6e83e4694f", size = 10858724, upload-time = "2026-06-04T00:52:07.843Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/29/5d80453e5f7c520145fa058851da87230dbd7ca761a7675447a9fe504e0b/ty-0.0.43-py3-none-win_amd64.whl", hash = "sha256:48d3545094a4ae6395492c7e6ac90550fce969e0ed2815fbf8c5da9756676b7d", size = 11976157, upload-time = "2026-06-04T00:52:41.438Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/ed/befe5a543e5b95e754ed38ee95239e44efda9bc5f578db4ac1bc8dd758d6/ty-0.0.43-py3-none-win_arm64.whl", hash = "sha256:740ca33d7f75f655a4e7d475bc42dfb825c13219bb073fad30fcc04d35790c74", size = 11308680, upload-time = "2026-06-04T00:52:39.233Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/48/bce79e7ca5c1cc529d3e0d37ddd1121aea4b68a4f749974ad1cc77161871/ty-0.0.56-py3-none-linux_armv6l.whl", hash = "sha256:186d4a53e15747c947e1ec3d7eec8e345d8e40a1ca10e634c585db52497e87dd", size = 11643066, upload-time = "2026-07-01T16:44:18.374Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d1/22555d8a1d719661f10050f3865d877bbf497da908961c75fe22217dd18a/ty-0.0.56-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aae1a980fd9535da0469b7ba2b2e1b54a907743a5e0f442dd57eee9f5bfd034c", size = 11407487, upload-time = "2026-07-01T16:44:20.956Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/2d/b3b7a74ce8bc59ef48843ad80179bb0d9598bbd6cfc0d11d519bdf6b1352/ty-0.0.56-py3-none-macosx_11_0_arm64.whl", hash = "sha256:afd3058c0a6c5f241e814734f133008c93ee805f61c9cf4ce7412b8822b5d9ad", size = 10962270, upload-time = "2026-07-01T16:44:22.959Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ac/6c2fd7de0304a8a7218a756af74f7e62a5e8540fdb175e0a869e51042345/ty-0.0.56-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:058b52f7a823ac13aae3cae30809dd6b5145794b64d8478f9ef38c75d79b4483", size = 11471406, upload-time = "2026-07-01T16:44:25.327Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b6/11d861156861c03c7726b74558f9a0e0092661aff83a4fda1279df28c425/ty-0.0.56-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c66e00c1522add1f2bbdd2e45828c953b35c306b7bef03ec9169c75a63699a0", size = 11445612, upload-time = "2026-07-01T16:44:27.531Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/ba/09df108582090f3c0770ec4bc8675affed60248f6793a78d909be16211d9/ty-0.0.56-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40903d71c669a30691b5a5d5728056c7877a1bd6be4f233a38883a8b28cf34d7", size = 12093889, upload-time = "2026-07-01T16:44:29.548Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/f7/dbb4b4ccb69cd64c209ae55b1ab788ace8222c2bc1f6845be9e7cbedbf25/ty-0.0.56-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63fe3947fe0c46c69a7d950e6832ee70a9ec17321fefbff3d2e3c20baf9e5bd0", size = 12666337, upload-time = "2026-07-01T16:44:31.586Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e9/73f903fe4a3d9ea02f26f57c1eb07e3b1029ec92b0e8c2364718893440e3/ty-0.0.56-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71a0c1a72f9854532e710e119b6871ffe4542c8a65146f1f65dcd78fecd885b4", size = 12280247, upload-time = "2026-07-01T16:44:33.637Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/90/cebd222495832f1a00dcd321ba25f3cab804221a4991b992c2178bec68ee/ty-0.0.56-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70d1665596494e24d8ebd198438872b5a56ec3cae5f2bcf6c673be797acc4e3c", size = 11991107, upload-time = "2026-07-01T16:44:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/07/8f7337a07250f42d975cdb6decf47fc5b421e6c7da5e3e7be1e85f63a7e5/ty-0.0.56-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:778f99e51558afc1dbbe48ee38ab6aae7b31390ed8c1a1ef1499b295e9f1e82f", size = 12298970, upload-time = "2026-07-01T16:44:38.243Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b9/a52cd59034a48f5f18c6b155cc2cc36861d874b6d0af204b12c898024c3d/ty-0.0.56-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:867bc5708e0066bb4ff6c7db524bd5deea2676c62bfe71d3303138b3be850af0", size = 11425683, upload-time = "2026-07-01T16:44:40.473Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2e/48e42d33357d52eefb695c0c3fcfc96879b73668a7447d1d1e0ad774fedc/ty-0.0.56-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a6012f4189c928edb330a37deb9930f982380bd4aa7c4b8e0428eec9651c7551", size = 11469258, upload-time = "2026-07-01T16:44:42.513Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/01/ad1b4138be1e3fa97863af3925aa2134f17a593240c35dc38c3429fb5ad1/ty-0.0.56-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8ee83de1a7ff4cc32837ec06134ce391d441bc5b35ecd8d3cfe053f120f3e4c1", size = 11758736, upload-time = "2026-07-01T16:44:44.567Z" },
+    { url = "https://files.pythonhosted.org/packages/09/34/9d81967ff240eaa57e9249728ef7b7790747cf6d3c9a98ec86b2cfdcc8ee/ty-0.0.56-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:62619b3b0e2c6248ef30d3f0e2f2217ae9893040585be07f32324242f197cd6f", size = 12100242, upload-time = "2026-07-01T16:44:46.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/36/f51d4666d2de6cf33c1f3a1fcc4bb6b70b197dd6ceaa491eef71d78fe8e8/ty-0.0.56-py3-none-win32.whl", hash = "sha256:b30687bb5cd9729d34c889a289edf32770388d9bb05243e534e723fb45e0381b", size = 11093759, upload-time = "2026-07-01T16:44:49.171Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b4/8fb5d4acfa4afb152245b20fa263069a7547bd1f8e4bfca4eda280c897d7/ty-0.0.56-py3-none-win_amd64.whl", hash = "sha256:ad4c8c47b6f4e3f9ed3fc0b1a5d650088d229e17dd8f63c1826d6bbe94cc3235", size = 12100327, upload-time = "2026-07-01T16:44:51.26Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fc/6a183e71edde90d0c35c2303f23f7a45b6891d1a2c45daf7b8f869831e19/ty-0.0.56-py3-none-win_arm64.whl", hash = "sha256:57538f273d444a5f1293fa7860e967178afe3917611fc5eff16b64e1204fe0d6", size = 11538780, upload-time = "2026-07-01T16:44:53.8Z" },
 ]
 
 [[package]]
@@ -1600,18 +1590,18 @@ wheels = [
 
 [[package]]
 name = "zizmor"
-version = "1.25.2"
+version = "1.26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b3/41/8987d546e3101cc76748b2f1b0ccda58e244773ef5124d39e7e749e3d6e4/zizmor-1.25.2.tar.gz", hash = "sha256:f26ffeb16659c8922c7b08203ca5a4f8bf5e1a7e8d190734961c40877cf778ea", size = 517794, upload-time = "2026-05-16T06:28:43.816Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/a0/a29b38e24981b4bb41db4f292b2c9fb9ddf8b05d6b724abddd7bd108b621/zizmor-1.26.1.tar.gz", hash = "sha256:0c2cc575007a4db99d89d5acc6120cfa7b61504bc2394c3b50af348c73f1916e", size = 535275, upload-time = "2026-06-21T02:47:21.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/bd/84108a92ccbfda0d28efc11f382997c7a767b58863bf4a550634b8cf0211/zizmor-1.25.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:17cc8cfd9d472e8b11945a869c198d25cfdf4a33f36fa7a1f9674099f5fb509d", size = 9115548, upload-time = "2026-05-16T06:28:33.591Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/c0/66453a2553a66286a96ca32d75e3e6bcc94ce7f907cd5f8c2c3fce55315e/zizmor-1.25.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d3e301eb4465e2da77857cf01ab4ef0184cf3818e826800b270ab01ae7338977", size = 8665071, upload-time = "2026-05-16T06:28:30.861Z" },
-    { url = "https://files.pythonhosted.org/packages/52/3e/d60939d1cc4907c0d021a7c46362aab5e8045550bb09157d56c070e43568/zizmor-1.25.2-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:cf64374149b567c9373228b76c8e77a389b4071899f84b82c36ee50fab894e79", size = 8842884, upload-time = "2026-05-16T06:28:26.041Z" },
-    { url = "https://files.pythonhosted.org/packages/46/82/f3e8d9b6d941194f2558591b449c106d46a16ea566b95eccff3a83bf6acc/zizmor-1.25.2-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:0beba1601be08bd00c9277e6ed4b026e125b26b379d86d6d98eb708409b3050d", size = 8449741, upload-time = "2026-05-16T06:28:45.424Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/13/445bc98acc2c976d6b8f8ca59b9c09f055adb5ffb3445d99af8ff7efcb4f/zizmor-1.25.2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:c4246f1344d8dbeffc044d7bb11b131773a7db7eb57d9073c45942dfd3543a1f", size = 9285184, upload-time = "2026-05-16T06:28:39.21Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/78/fc7717c706bde7531b2fde12003994fbc04c47ab4f91aa6ca9b3b24b30fd/zizmor-1.25.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:dbb1b5c85b8de8eaa0227c6620f06c8e4fbd0a4da2086e218bc225c0bef0923d", size = 8886579, upload-time = "2026-05-16T06:28:51.384Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/bc/a46f11377cdc145c625d62d88c30fead56f9d29bc31652069a1a0eaed6c2/zizmor-1.25.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:d670a1e2f00b3cd56febd145bc1a0b2c4caf1cbe5dad8128721843fa877e2d2e", size = 8413576, upload-time = "2026-05-16T06:28:36.376Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/3b/0fd93b77171c8f229e8e1304eecc9931bf3009f722c57967d545d9f151b6/zizmor-1.25.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b75c84d7387389f95edadbe859fb2aaf0a360c5b080932cc53e92ae1db6f09ef", size = 9378162, upload-time = "2026-05-16T06:28:41.999Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/3f/dcb85fb9a0d87794847f9043f9db9bb4d274cf4b8077604bc13850c8fdb4/zizmor-1.25.2-py3-none-win32.whl", hash = "sha256:aa9f4c43b499c55339c3ef2e885133c5017cd9a18d76d9335541203cfa5ae1e7", size = 7548509, upload-time = "2026-05-16T06:28:28.828Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/81/1cb088098bd53f9b910098b0c19d06dc587acf328a170ef8afd1cd93b482/zizmor-1.25.2-py3-none-win_amd64.whl", hash = "sha256:af55bd9bd119ea8cbce2a7addc3922503019de32c1fe31106d70b3dc77d77908", size = 8609822, upload-time = "2026-05-16T06:28:48.078Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a9/2f47f7db8db9491025e00a7f1a0f25d32b642c0285b2fe070ac63e679b47/zizmor-1.26.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7ea21ca959c8e888de238fee81d73a1fdf89a82067eac75b8f1acdbd23e2eeaf", size = 9086061, upload-time = "2026-06-21T02:46:57.492Z" },
+    { url = "https://files.pythonhosted.org/packages/58/92/cf6801f01e1d65cbda89a2e2926ea42caf1daad9ffa3f1fc88e4c68f48a9/zizmor-1.26.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:78083b495593f8b0b9dec14036a0836a5afcddda8a40738336ff4e399476b741", size = 8626865, upload-time = "2026-06-21T02:47:00.323Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b1/ff38fc2921f1fb13244bb3a3642c4b45ecf3946c279942aafcb5dbf55a57/zizmor-1.26.1-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:bb7ebbe565a3742eb49a590352127ad549bb122b9b4ff9424ebab7525fa3b6b6", size = 8843965, upload-time = "2026-06-21T02:47:03.318Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/06/c07fd0eeef0427d93e99d552d5386526fbcd0bf05fc95cd37bdc6229fccb/zizmor-1.26.1-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:d3049010b6bd6f849413b6d20c28e0c677b90e0a5b2bc73cbee7f7bd86dc5828", size = 8386985, upload-time = "2026-06-21T02:47:05.741Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2b/61ab13d45d6ce57ef5a08bb3246981f62e30bb4938098b17bb7b88110b79/zizmor-1.26.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:6a958d8a0941d7e1d0de8436670b5cb7fc64c8028b4d16e3f519ccc77f953cef", size = 9257232, upload-time = "2026-06-21T02:47:07.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ad/bd74a96cb02045414ec5b573cd97ff3b82a97fd0bd6658f93c36a011c439/zizmor-1.26.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d2744cdf944436ca7a009ae8b626a017a40381ec990216abd6cf6b8beb23323a", size = 8873798, upload-time = "2026-06-21T02:47:10.472Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7e/fb3d608ee11e2f619d43ad93bab46eb7b32769fa82b1d86fd23f27c2585b/zizmor-1.26.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:44099f426af9da750ff9f548a0084e11d7d83e0158fe1a2778672398d728efdd", size = 8350857, upload-time = "2026-06-21T02:47:12.748Z" },
+    { url = "https://files.pythonhosted.org/packages/27/cc/82d7a838c2d490071555c364f90eb851044b3eeefc1d68612179a2cd1ae5/zizmor-1.26.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8313cc264dec792f00a7328eb7c8e89e7d62d54f950fc897d1e6a5a6e5762203", size = 9351148, upload-time = "2026-06-21T02:47:14.777Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ee/d2a2301f30b9e1bf0d721bfd31739acd71e048757f9ba79279583eb30ac0/zizmor-1.26.1-py3-none-win32.whl", hash = "sha256:c96d7787d69fb298eae939e00dfdf7f534d7dfbd9cc17ab442c0650a56851415", size = 7531021, upload-time = "2026-06-21T02:47:17.247Z" },
+    { url = "https://files.pythonhosted.org/packages/91/58/ad561f3a5057d3c0f152002e180a3a5745e72ea9d69bf66450ef9f5d3fe5/zizmor-1.26.1-py3-none-win_amd64.whl", hash = "sha256:0a05acf6068609fb6df3b137276cf18a686226a1e0e207941cb34a85929f16cf", size = 8616584, upload-time = "2026-06-21T02:47:19.094Z" },
 ]


### PR DESCRIPTION
Removes the obsolete `pyright: ignore[reportUnknownMemberType]` suppressions from `pytester.makepyfile` calls now that pytest-dev/pytest#14080 has merged.

Pins uv's local pytest source to the merged fix commit because the latest released pytest used by the lock still lacks that annotation. Regenerates `uv.lock`, which also syncs the existing dev tool pins from `pyproject.toml`.

Validated with the pre-commit/pre-push hook suite plus focused pyright, pytest, ruff, pyproject-fmt, and `uv lock --check` runs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect dev dependencies and test typing only; the plugin runtime code is untouched.
> 
> **Overview**
> Drops **pyright** workarounds around `pytester.makepyfile` in `tests/test_plugin.py` (no more `reportUnknownMemberType` ignores or discarded `_ =` calls) now that pytest-dev/pytest#14080 is merged upstream.
> 
> Because released pytest still lacks that typing fix, **`[tool.uv]`** pins `pytest` to the merged commit on `pytest-dev/pytest` until a release ships it. **`uv.lock`** is regenerated accordingly and picks up the dev-tool version bumps already declared in `pyproject.toml` (prek, pylint, pyproject-fmt, pyrefly, pyright, ruff, strict-kwargs, ty, zizmor).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c886b598571001d1b8018e8dc62bc287c79b27b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->