### PR TITLE
Lint reStructuredText prose with Vale to ban em dashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Vale styles downloaded by ``vale sync``
+styles/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -188,6 +188,34 @@ repos:
           - *uv_version
         require_serial: true
 
+      # Vale enforces prose style rules, such as banning em dashes, in
+      # reStructuredText files.
+      # The rules come from the ``ClearProse`` package pinned in ``.vale.ini``,
+      # which ``vale sync`` downloads into the (gitignored) ``styles``
+      # directory.
+      # Vale needs ``rst2html`` from Docutils on the ``PATH`` to parse
+      # reStructuredText.
+      # ``vale sync`` also runs when ``.vale.ini`` changes, so a package
+      # bump takes effect without waiting for the next reStructuredText
+      # change.
+      - id: vale-sync
+        name: vale sync
+        entry: uv run --extra=dev vale sync
+        language: python
+        pass_filenames: false
+        files: (\.rst$|^\.vale\.ini$)
+        additional_dependencies:
+          - *uv_version
+
+      - id: vale
+        name: vale
+        entry: uv run --extra=dev vale
+        language: python
+        types_or: [rst]
+        require_serial: true
+        additional_dependencies:
+          - *uv_version
+
       - id: interrogate
         name: interrogate
         entry: uv run --extra=dev -m interrogate

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,7 @@
+StylesPath = styles
+MinAlertLevel = error
+
+Packages = https://github.com/adamtheturtle/vale-style-clear-prose/releases/download/v1.1.0/ClearProse.zip
+
+[*.rst]
+BasedOnStyles = ClearProse

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Install
 
    uv add --dev pytest-beartype-tests
 
-The plugin auto-registers via the ``pytest11`` entry point — there is no configuration.
+The plugin auto-registers via the ``pytest11`` entry point, so there is no configuration.
 
 What it does
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ optional-dependencies.dev = [
     "strict-kwargs==2026.7.24",
     "towncrier==25.8.0",
     "ty==0.0.65",
+    "vale==3.13.0.0",
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.29.0",
@@ -193,6 +194,7 @@ omit-covered-files = true
 [tool.check-manifest]
 ignore = [
     ".pre-commit-config.yaml",
+    ".vale.ini",
     "CHANGELOG.rst",
     "conftest.py",
     "LICENSE",

--- a/uv.lock
+++ b/uv.lock
@@ -1211,6 +1211,7 @@ dev = [
     { name = "strict-kwargs" },
     { name = "towncrier" },
     { name = "ty" },
+    { name = "vale" },
     { name = "vulture" },
     { name = "yamlfix" },
     { name = "zizmor" },
@@ -1247,6 +1248,7 @@ requires-dist = [
     { name = "towncrier", marker = "extra == 'dev'", specifier = "==25.8.0" },
     { name = "towncrier", marker = "extra == 'release'", specifier = "==25.8.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.65" },
+    { name = "vale", marker = "extra == 'dev'", specifier = "==3.13.0.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = "==2.16" },
     { name = "yamlfix", marker = "extra == 'dev'", specifier = "==1.19.1" },
     { name = "zizmor", marker = "extra == 'dev'", specifier = "==1.29.0" },
@@ -1563,6 +1565,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "vale"
+version = "3.13.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/0d/6ebd7d020135888cc4d35290737871986ceabf176ba5e44827294429283a/vale-3.13.0.0.tar.gz", hash = "sha256:9c2482ecab515e58aa8d7e1a09f3d44ed674a07502786e22ff60c9d4fdc8493b", size = 5340, upload-time = "2025-10-28T13:20:41.459Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/05/92b9e4d3e3cb424d2a1aa6e070ee838f15f6739a90b06964156a24fe49ce/vale-3.13.0.0-py3-none-any.whl", hash = "sha256:b565197a5f6e430af7ccc59204e75c6067bbd091a0073d700efdd0fba21873ed", size = 5944, upload-time = "2025-10-28T13:20:40.35Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds Vale as a pre-commit hook so em dashes cannot creep into our reStructuredText.

The rules come from the pinned [ClearProse](https://github.com/adamtheturtle/vale-style-clear-prose) style package (v1.1.0) rather than a hand-written local rule, configured in a new `.vale.ini`; `vale sync` downloads it into a gitignored `styles/` directory before the lint runs. That release ships as a Vale config package, so it carries the `TokenIgnores` pattern that keeps Sphinx role targets such as `:ref:` out of the prose check. `vale==3.13.0.0` is pinned in the dev extra, and `.vale.ini` is added to the `check-manifest` ignores.

The em dashes already present in the prose are rewritten in the same change, so the lint passes on the existing files.

Verified locally: `vale` reports no alerts across the tracked `.rst` files, and `prek run` over the changed files passes.

Note that the `vale` PyPI wrapper is behind the upstream binary (3.13.0 against 3.17.1), and 3.13.0 drops the occasional alert: on the ClearProse fixture with seven em dashes it reports six, where 3.17.1 reports all seven. The ban still holds, because a file with an em dash is still reported, but the pin is worth bumping when the wrapper publishes a newer Vale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only tooling and documentation wording; no runtime, security, or packaging behavior changes for the library.
> 
> **Overview**
> Adds **Vale** prose linting for `*.rst` files via pre-commit, using the pinned **ClearProse** style package in a new `.vale.ini`. A **`vale sync`** hook downloads styles into gitignored `styles/` (also triggered when `.vale.ini` changes); **`vale`** runs on RST changes. **`vale==3.13.0.0`** is added to the dev extra and **`uv.lock`** is updated; **`.vale.ini`** is listed in **`check-manifest`** ignores.
> 
> **README.rst** is adjusted so existing prose passes the new rules (e.g. em dash replaced with a comma in the install blurb).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ed8bcf19800a3120f15a0e72b3df76d7f3d5350. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->