### PR TITLE
Avoid overused changelog wording

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 2026.08.16
 ----------
 
-No significant changes.
+No documented changes.
 
 2026.04.26
 ----------


### PR DESCRIPTION
## What changed

- Replace the existing “No significant changes” changelog text with “No documented changes”.
- Update the Towncrier template where present so future empty releases remain Vale-compliant.

## Why

The synced ClearProse rules now flag “significant” as overused vocabulary, breaking the default branch and open Dependabot PRs during lint.

## Validation

- Vale sync and Vale checks
- repository commit and push hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog wording only; no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates the **2026.08.16** release entry in `CHANGELOG.rst` from “No significant changes.” to **“No documented changes.”** so changelog copy passes synced ClearProse/Vale rules that treat “significant” as overused vocabulary (which was failing default-branch and Dependabot lint).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91744967364aef688b01d9dff588a4889992ae0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->